### PR TITLE
docs(README): improve onboarding for first-time users

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,44 @@ Supports **multiple languages**, **multiple output formats**, and **any LLM**.
 
 ## Quick Start
 
+### 1. Install
+
 ```bash
-# Install directly from GitHub (recommended until published to PyPI)
+# Recommended: uv (fastest)
+uv tool install gitlog
+
+# Or pip
+pip install gitlog
+
+# Or install directly from GitHub
 pip install git+https://github.com/JToSound/LogForge.git
+```
+
+**Requirements:** Python 3.11+ and Git.
+
+### 2. Configure your API key
+
+```bash
+# Option A: environment variable (recommended for CI)
+export OPENAI_API_KEY="sk-..."
+
+# Option B: .env file in your repo root
+echo "OPENAI_API_KEY=sk-..." > .env
+
+# Option C: use a local model (no key needed)
+gitlog generate --model ollama/llama3
+```
+
+### 3. Generate your first changelog
+
+```bash
 cd your-repo
-export OPENAI_API_KEY=sk-...
 gitlog generate
 ```
 
 That's it. Your `CHANGELOG.md` is ready. 🎉
+
+> **New to gitlog?** Run `gitlog init` for an interactive setup wizard that creates a `.gitlog.toml` tailored to your project.
 
 ---
 


### PR DESCRIPTION
Closes #9

This PR refines the top README section for faster first-run success:

- Split Quick Start into 3 clear steps (Install -> Configure -> Generate) so newcomers are not overwhelmed by a single code block.
- Added multiple API-key setup options: environment variable, .env file, or local Ollama model (no key needed).
- Mentioned requirements (Python 3.11+, Git) up front so users know if they are ready before installing.
- Added a pointer to gitlog init as a friendly next step for users who want interactive setup.

All existing sections remain unchanged.